### PR TITLE
Add Node.js engine declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "description": "3dstreamingtoolkit webrtc signal implementation, using http",
   "main": "index.js",
+  "engine": {
+    "node": "10.14.1"
+  },
   "bin": {
     "3dtoolkit-signal": "./index.js"
   },


### PR DESCRIPTION
When deploying to Azure, App Services defaults the Node Version to some 6.x

This is incompatible with this project so we are using the package.json engine property to tell AAS to use Node JS LTS 10.14.1 instead.